### PR TITLE
Make `lib` project executable (as console app)

### DIFF
--- a/lib/Class1.cs
+++ b/lib/Class1.cs
@@ -5,7 +5,13 @@ namespace lib
 {
     public class Class1
     {
-        public string UseJsonNetForSomeReason<T>(T input) {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello world!");
+        }
+
+        public string UseJsonNetForSomeReason<T>(T input)
+        {
             return JsonConvert.SerializeObject(input);
         }
     }

--- a/lib/lib.csproj
+++ b/lib/lib.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />


### PR DESCRIPTION
We give this library to candidates to help simplify their interview experience at Stripe. However, the `lib` project's code in the current setup may be executed only through the unit tests. While a reasonable setup in practice, for the interview, is is completely acceptable to run code by running the program directly (via `Main`).

I'm changing `lib`'s project to core app with executable output type so that candidates can run it.

I've pinned to the older dotnetcore2.0 rather than a new version for consistency with netstandard2.0 and to cast a wider net for candidates who may not have a completely up-to-date setup.

This parallels the sample in our [java-interview-prep](https://github.com/stripe/java-interview-prep/blob/203459a3d81b6708898826b9ca232b8d1b80f74b/src/main/java/com/stripe/interview/Main.java#L6) repo.